### PR TITLE
Remove zingchart dependency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -9,7 +9,6 @@
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.0",
     "react-scripts": "3.0.1",
-    "zingchart-react": "^1.0.6"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
I'm removing this dependency since we have shifted to d3.js